### PR TITLE
Update with changes for the new characters system

### DIFF
--- a/data/categories.json
+++ b/data/categories.json
@@ -1,7 +1,4 @@
 {
-    "((~Start~))": {
-        "hidden": false
-    },
     "Arcade": {
         "hidden": true
     },
@@ -61,5 +58,11 @@
     },
     "N. Oxide": {
         "hidden": true
+    },
+    "Characters": {
+        "hidden": false
+	},
+    "Unloackable": {
+        "hidden": false
     }
 }

--- a/data/categories.json
+++ b/data/categories.json
@@ -62,7 +62,7 @@
     "Characters": {
         "hidden": false
 	},
-    "Unloackable": {
-        "hidden": false
+    "Unlockable": {
+        "hidden": true
     }
 }

--- a/data/categories.json
+++ b/data/categories.json
@@ -56,6 +56,9 @@
     "N. Tropy": {
         "hidden": true
     },
+    "N. Tropy Loc": {
+        "hidden": true
+    },
     "N. Oxide": {
         "hidden": true
     },

--- a/data/game.json
+++ b/data/game.json
@@ -3,7 +3,7 @@
   "creator": "Hallstead",
   "filler_item_name": "WOAH"
   "starting_items": [
-    {"item_categories": ["Tracks"]}
-	{"item_categories": ["Characters"]}
+    {"item_categories": ["Tracks"]},
+    {"item_categories": ["Characters"]}
   ]
 }

--- a/data/game.json
+++ b/data/game.json
@@ -1,7 +1,7 @@
 {
   "game": "CrashTeamRacing",
   "creator": "Hallstead",
-  "filler_item_name": "WOAH"
+  "filler_item_name": "WOAH",
   "starting_items": [
     {"item_categories": ["Tracks"]},
     {"item_categories": ["Characters"]}

--- a/data/game.json
+++ b/data/game.json
@@ -3,7 +3,13 @@
   "creator": "Hallstead",
   "filler_item_name": "WOAH",
   "starting_items": [
-    {"item_categories": ["Tracks"]},
-    {"item_categories": ["Characters"]}
+    {
+      "item_categories": ["Tracks"],
+      "random": 1
+    },
+    {
+      "item_categories": ["Characters"],
+      "random": 1
+    }
   ]
 }

--- a/data/game.json
+++ b/data/game.json
@@ -2,4 +2,8 @@
   "game": "CrashTeamRacing",
   "creator": "Hallstead",
   "filler_item_name": "WOAH"
+  "starting_items": [
+    {"item_categories": ["Tracks"]}
+	{"item_categories": ["Characters"]}
+  ]
 }

--- a/data/items.json
+++ b/data/items.json
@@ -410,43 +410,43 @@
 	{
 		"count":1,
 		"name": "Ripper Roo",
-		"category": ["Unlockable"],
+		"category": ["Characters", "Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Papu Papu",
-		"category": ["Unlockable"],
+		"category": ["Characters", "Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Komodo Joe",
-		"category": ["Unlockable"],
+		"category": ["Characters", "Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Pinstripe",
-		"category": ["Unlockable"],
+		"category": ["Characters", "Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Fake Crash",
-		"category": ["Unlockable"],
+		"category": ["Characters", "Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "N. Tropy",
-		"category": ["Unlockable"],
+		"category": ["Characters", "Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Penta Penguin",
-		"category": ["Unlockable"],
+		"category": ["Characters", "Unlockable"],
 		"filler": true
 	}
 ]

--- a/data/items.json
+++ b/data/items.json
@@ -18,9 +18,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Crash Cove - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Crash Cove - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -30,9 +36,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Mystery Caves - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Mystery Caves - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -42,9 +54,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Sewer Speedway - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Sewer Speedway - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -54,9 +72,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Roo's Tubes - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Roo's Tubes - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -66,9 +90,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Slide Coliseum - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Slide Coliseum - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -78,9 +108,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Turbo Track - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy", "TTrack"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Turbo Track - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide", "TTrack"],
+		"category": ["Time Trial", "Classic", "N. Oxide", "TTrack"],
 		"progression": true
 	},
 	{
@@ -90,9 +126,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Coco Park - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Coco Park - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -102,9 +144,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Tiger Temple - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Tiger Temple - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -114,9 +162,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Papu's Pyramid - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Papu's Pyramid - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -126,9 +180,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Dingo Canyon - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Dingo Canyon - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -138,9 +198,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Polar Pass - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Polar Pass - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -150,9 +216,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Tiny Arena - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Tiny Arena - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -162,9 +234,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Dragon Mines - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Dragon Mines - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -174,9 +252,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Blizzard Bluff - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Blizzard Bluff - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -186,9 +270,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Hot Air Skyway - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Hot Air Skyway - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -198,9 +288,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Cortex Castle - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Cortex Castle - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -210,9 +306,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "N. Gin Labs - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "N. Gin Labs - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -222,9 +324,15 @@
 		"progression": true
 	},
 	{
+		"count":1,
+		"name": "Oxide Station - N. Tropy",
+		"category": ["Time Trial", "Classic", "N. Tropy"],
+		"progression": true
+	},
+	{
 		"count":2,
 		"name": "Oxide Station - Progressive Ghost",
-		"category": ["Time Trial", "Classic", "N. Tropy", "N. Oxide"],
+		"category": ["Time Trial", "Classic", "N. Oxide"],
 		"progression": true
 	},
 	{
@@ -302,43 +410,43 @@
 	{
 		"count":1,
 		"name": "Ripper Roo",
-		"category": ["Characters"],
+		"category": ["Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Papu Papu",
-		"category": ["Characters"],
+		"category": ["Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Komodo Joe",
-		"category": ["Characters"],
+		"category": ["Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Pinstripe",
-		"category": ["Characters"],
+		"category": ["Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Fake Crash",
-		"category": ["Characters"],
+		"category": ["Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "N. Tropy",
-		"category": ["Characters"],
+		"category": ["Unlockable"],
 		"filler": true
 	},
 	{
 		"count":1,
 		"name": "Penta Penguin",
-		"category": ["Characters"],
+		"category": ["Unlockable"],
 		"filler": true
 	}
 ]

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,11 +1,5 @@
 [
 {
-	"name": "Starting Track",
-	"category": ["((~Start~))"],
-	"requires": [],
-	"place_item_category": ["Tracks"]
-},
-{
 	"name": "Goal (All Trophies)",
 	"victory": true,
 	"requires": "|Ultimate Trophy (Victory)|",
@@ -2504,12 +2498,12 @@
   {
     "name": "Crash Cove Time Trial - Beat N. Tropy",
     "category": ["Track - Crash Cove", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Crash Cove| and |Crash Cove - Progressive Ghost:1|"
+    "requires": "(|Crash Cove| AND |Crash Cove - N. Tropy|) OR (|Crash Cove| AND {YamlEnabled(option_n_oxide)} AND |Crash Cove - Progressive Ghost:1|})"
   },
   {
     "name": "Crash Cove Time Trial - Beat N. Oxide",
     "category": ["Track - Crash Cove", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Crash Cove| and |Crash Cove - Progressive Ghost:2|"
+    "requires": "|Crash Cove| AND |Crash Cove - Progressive Ghost:2|"
   },
   {
     "name": "Roo's Tubes Time Trial - Unlock N. Tropy",
@@ -2519,12 +2513,12 @@
   {
     "name": "Roo's Tubes Time Trial - Beat N. Tropy",
     "category": ["Track - Roo's Tubes", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Roo's Tubes| and |Roo's Tubes - Progressive Ghost:1|"
+    "requires": "(|Roo's Tubes| AND |Roo's Tubes - N. Tropy|) OR (|Roo's Tubes| AND {YamlEnabled(option_n_oxide)} AND |Roo's Tubes - Progressive Ghost:1|})"
   },
   {
     "name": "Roo's Tubes Time Trial - Beat N. Oxide",
     "category": ["Track - Roo's Tubes", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Roo's Tubes| and |Roo's Tubes - Progressive Ghost:2|"
+    "requires": "|Roo's Tubes| AND |Roo's Tubes - Progressive Ghost:2|"
   },
   {
     "name": "Mystery Caves Time Trial - Unlock N. Tropy",
@@ -2534,12 +2528,12 @@
   {
     "name": "Mystery Caves Time Trial - Beat N. Tropy",
     "category": ["Track - Mystery Caves", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Mystery Caves| and |Mystery Caves - Progressive Ghost:1|"
+    "requires": "|Mystery Caves| AND |Mystery Caves - N. Tropy|) OR (|Mystery Caves| AND {YamlEnabled(option_n_oxide)} AND |Mystery Caves - Progressive Ghost:1|})"
   },
   {
     "name": "Mystery Caves Time Trial - Beat N. Oxide",
     "category": ["Track - Mystery Caves", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Mystery Caves| and |Mystery Caves - Progressive Ghost:2|"
+    "requires": "|Mystery Caves| AND |Mystery Caves - Progressive Ghost:2|"
   },
   {
     "name": "Sewer Speedway Time Trial - Unlock N. Tropy",
@@ -2549,12 +2543,12 @@
   {
     "name": "Sewer Speedway Time Trial - Beat N. Tropy",
     "category": ["Track - Sewer Speedway", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Sewer Speedway| and |Sewer Speedway - Progressive Ghost:1|"
+    "requires": "(|Sewer Speedway| AND |Sewer Speedway - N. Tropy|) OR (|Sewer Speedway| AND {YamlEnabled(option_n_oxide)} AND |Sewer Speedway - Progressive Ghost:1|})"
   },
   {
     "name": "Sewer Speedway Time Trial - Beat N. Oxide",
     "category": ["Track - Sewer Speedway", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Sewer Speedway| and |Sewer Speedway - Progressive Ghost:2|"
+    "requires": "|Sewer Speedway| AND |Sewer Speedway - Progressive Ghost:2|"
   },
   {
     "name": "Coco Park Time Trial - Unlock N. Tropy",
@@ -2564,12 +2558,12 @@
   {
     "name": "Coco Park Time Trial - Beat N. Tropy",
     "category": ["Track - Coco Park", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Coco Park| and |Coco Park - Progressive Ghost:1|"
+    "requires": "(|Coco Park| AND |Coco Park - N. Tropy|) OR (|Coco Park| AND {YamlEnabled(option_n_oxide)} AND |Coco Park - Progressive Ghost:1|})"
   },
   {
     "name": "Coco Park Time Trial - Beat N. Oxide",
     "category": ["Track - Coco Park", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Coco Park| and |Coco Park - Progressive Ghost:2|"
+    "requires": "|Coco Park| AND |Coco Park - Progressive Ghost:2|"
   },
   {
     "name": "Tiger Temple Time Trial - Unlock N. Tropy",
@@ -2579,12 +2573,12 @@
   {
     "name": "Tiger Temple Time Trial - Beat N. Tropy",
     "category": ["Track - Tiger Temple", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Tiger Temple| and |Tiger Temple - Progressive Ghost:1|"
+    "requires": "(|Tiger Temple| AND |Tiger Temple - N. Tropy|) OR (|Tiger Temple| AND {YamlEnabled(option_n_oxide)} AND |Tiger Temple - Progressive Ghost:1|})"
   },
   {
     "name": "Tiger Temple Time Trial - Beat N. Oxide",
     "category": ["Track - Tiger Temple", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Tiger Temple| and |Tiger Temple - Progressive Ghost:2|"
+    "requires": "|Tiger Temple| AND |Tiger Temple - Progressive Ghost:2|"
   },
   {
     "name": "Papu's Pyramid Time Trial - Unlock N. Tropy",
@@ -2594,12 +2588,12 @@
   {
     "name": "Papu's Pyramid Time Trial - Beat N. Tropy",
     "category": ["Track - Papu's Pyramid", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Papu's Pyramid| and |Papu's Pyramid - Progressive Ghost:1|"
+    "requires": "(|Papu's Pyramid| AND |Papu's Pyramid - N. Tropy|) OR (|Papu's Pyramid| AND {YamlEnabled(option_n_oxide)} AND |Papu's Pyramid - Progressive Ghost:1|})"
   },
   {
     "name": "Papu's Pyramid Time Trial - Beat N. Oxide",
     "category": ["Track - Papu's Pyramid", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Papu's Pyramid| and |Papu's Pyramid - Progressive Ghost:2|"
+    "requires": "|Papu's Pyramid| AND |Papu's Pyramid - Progressive Ghost:2|"
   },
   {
     "name": "Dingo Canyon Time Trial - Unlock N. Tropy",
@@ -2609,12 +2603,12 @@
   {
     "name": "Dingo Canyon Time Trial - Beat N. Tropy",
     "category": ["Track - Dingo Canyon", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Dingo Canyon| and |Dingo Canyon - Progressive Ghost:1|"
+    "requires": "(|Dingo Canyon| AND |Dingo Canyon - N. Tropy|) OR (|Dingo Canyon| AND {YamlEnabled(option_n_oxide)} AND |Dingo Canyon - Progressive Ghost:1|})"
   },
   {
     "name": "Dingo Canyon Time Trial - Beat N. Oxide",
     "category": ["Track - Dingo Canyon", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Dingo Canyon| and |Dingo Canyon - Progressive Ghost:2|"
+    "requires": "|Dingo Canyon| AND |Dingo Canyon - Progressive Ghost:2|"
   },
   {
     "name": "Blizzard Bluff Time Trial - Unlock N. Tropy",
@@ -2624,12 +2618,12 @@
   {
     "name": "Blizzard Bluff Time Trial - Beat N. Tropy",
     "category": ["Track - Blizzard Bluff", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Blizzard Bluff| and |Blizzard Bluff - Progressive Ghost:1|"
+    "requires": "(|Blizzard Bluff| AND |Blizzard Bluff - N. Tropy|) OR (|Blizzard Bluff| AND {YamlEnabled(option_n_oxide)} AND |Blizzard Bluff - Progressive Ghost:1|})"
   },
   {
     "name": "Blizzard Bluff Time Trial - Beat N. Oxide",
     "category": ["Track - Blizzard Bluff", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Blizzard Bluff| and |Blizzard Bluff - Progressive Ghost:2|"
+    "requires": "|Blizzard Bluff| AND |Blizzard Bluff - Progressive Ghost:2|"
   },
   {
     "name": "Dragon Mines Time Trial - Unlock N. Tropy",
@@ -2639,12 +2633,12 @@
   {
     "name": "Dragon Mines Time Trial - Beat N. Tropy",
     "category": ["Track - Dragon Mines", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Dragon Mines| and |Dragon Mines - Progressive Ghost:1|"
+    "requires": "(|Dragon Mines| AND |Dragon Mines - N. Tropy|) OR (|Dragon Mines| AND {YamlEnabled(option_n_oxide)} AND |Dragon Mines - Progressive Ghost:1|})"
   },
   {
     "name": "Dragon Mines Time Trial - Beat N. Oxide",
     "category": ["Track - Dragon Mines", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Dragon Mines| and |Dragon Mines - Progressive Ghost:2|"
+    "requires": "|Dragon Mines| AND |Dragon Mines - Progressive Ghost:2|"
   },
   {
     "name": "Polar Pass Time Trial - Unlock N. Tropy",
@@ -2654,12 +2648,12 @@
   {
     "name": "Polar Pass Time Trial - Beat N. Tropy",
     "category": ["Track - Polar Pass", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Polar Pass| and |Polar Pass - Progressive Ghost:1|"
+    "requires": "(|Polar Pass| AND |Polar Pass - N. Tropy|) OR (|Polar Pass| AND {YamlEnabled(option_n_oxide)} AND |Polar Pass - Progressive Ghost:1|})"
   },
   {
     "name": "Polar Pass Time Trial - Beat N. Oxide",
     "category": ["Track - Polar Pass", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Polar Pass| and |Polar Pass - Progressive Ghost:2|"
+    "requires": "|Polar Pass| AND |Polar Pass - Progressive Ghost:2|"
   },
   {
     "name": "Tiny Arena Time Trial - Unlock N. Tropy",
@@ -2669,12 +2663,12 @@
   {
     "name": "Tiny Arena Time Trial - Beat N. Tropy",
     "category": ["Track - Tiny Arena", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Tiny Arena| and |Tiny Arena - Progressive Ghost:1|"
+    "requires": "(|Tiny Arena| AND |Tiny Arena - N. Tropy|) OR (|Tiny Arena| AND {YamlEnabled(option_n_oxide)} AND |Tiny Arena - Progressive Ghost:1|})"
   },
   {
     "name": "Tiny Arena Time Trial - Beat N. Oxide",
     "category": ["Track - Tiny Arena", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Tiny Arena| and |Tiny Arena - Progressive Ghost:2|"
+    "requires": "|Tiny Arena| AND |Tiny Arena - Progressive Ghost:2|"
   },
   {
     "name": "N. Gin Labs Time Trial - Unlock N. Tropy",
@@ -2684,12 +2678,12 @@
   {
     "name": "N. Gin Labs Time Trial - Beat N. Tropy",
     "category": ["Track - N. Gin Labs", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|N. Gin Labs| and |N. Gin Labs - Progressive Ghost:1|"
+    "requires": "(|N. Gin Labs| AND |N. Gin Labs - N. Tropy|) OR (|N. Gin Labs| AND {YamlEnabled(option_n_oxide)} AND |N. Gin Labs - Progressive Ghost:1|})"
   },
   {
     "name": "N. Gin Labs Time Trial - Beat N. Oxide",
     "category": ["Track - N. Gin Labs", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|N. Gin Labs| and |N. Gin Labs - Progressive Ghost:2|"
+    "requires": "|N. Gin Labs| AND |N. Gin Labs - Progressive Ghost:2|"
   },
   {
     "name": "Cortex Castle Time Trial - Unlock N. Tropy",
@@ -2699,12 +2693,12 @@
   {
     "name": "Cortex Castle Time Trial - Beat N. Tropy",
     "category": ["Track - Cortex Castle", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Cortex Castle| and |Cortex Castle - Progressive Ghost:1|"
+    "requires": "(|Cortex Castle| AND |Cortex Castle - N. Tropy|) OR (|Cortex Castle| AND {YamlEnabled(option_n_oxide)} AND |Cortex Castle - Progressive Ghost:1|})"
   },
   {
     "name": "Cortex Castle Time Trial - Beat N. Oxide",
     "category": ["Track - Cortex Castle", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Cortex Castle| and |Cortex Castle - Progressive Ghost:2|"
+    "requires": "|Cortex Castle| AND |Cortex Castle - Progressive Ghost:2|"
   },
   {
     "name": "Hot Air Skyway Time Trial - Unlock N. Tropy",
@@ -2714,12 +2708,12 @@
   {
     "name": "Hot Air Skyway Time Trial - Beat N. Tropy",
     "category": ["Track - Hot Air Skyway", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Hot Air Skyway| and |Hot Air Skyway - Progressive Ghost:1|"
+    "requires": "(|Hot Air Skyway| AND |Hot Air Skyway - N. Tropy|) OR (|Hot Air Skyway| AND {YamlEnabled(option_n_oxide)} AND |Hot Air Skyway - Progressive Ghost:1|})"
   },
   {
     "name": "Hot Air Skyway Time Trial - Beat N. Oxide",
     "category": ["Track - Hot Air Skyway", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Hot Air Skyway| and |Hot Air Skyway - Progressive Ghost:2|"
+    "requires": "|Hot Air Skyway| AND |Hot Air Skyway - Progressive Ghost:2|"
   },
   {
     "name": "Oxide Station Time Trial - Unlock N. Tropy",
@@ -2729,12 +2723,12 @@
   {
     "name": "Oxide Station Time Trial - Beat N. Tropy",
     "category": ["Track - Oxide Station", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Oxide Station| and |Oxide Station - Progressive Ghost:1|"
+    "requires": "(|Oxide Station| AND |Oxide Station - N. Tropy|) OR (|Oxide Station| AND {YamlEnabled(option_n_oxide)} AND |Oxide Station - Progressive Ghost:1|})"
   },
   {
     "name": "Oxide Station Time Trial - Beat N. Oxide",
     "category": ["Track - Oxide Station", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Oxide Station| and |Oxide Station - Progressive Ghost:2|"
+    "requires": "|Oxide Station| AND |Oxide Station - Progressive Ghost:2|"
   },
   {
     "name": "Slide Coliseum Time Trial - Unlock N. Tropy",
@@ -2744,12 +2738,12 @@
   {
     "name": "Slide Coliseum Time Trial - Beat N. Tropy",
     "category": ["Track - Slide Coliseum", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Slide Coliseum| and |Slide Coliseum - Progressive Ghost:1|"
+    "requires": "(|Slide Coliseum| AND |Slide Coliseum - N. Tropy|) OR (|Slide Coliseum| AND {YamlEnabled(option_n_oxide)} AND |Slide Coliseum - Progressive Ghost:1|})"
   },
   {
     "name": "Slide Coliseum Time Trial - Beat N. Oxide",
     "category": ["Track - Slide Coliseum", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Slide Coliseum| and |Slide Coliseum - Progressive Ghost:2|"
+    "requires": "|Slide Coliseum| AND |Slide Coliseum - Progressive Ghost:2|"
   },
   {
     "name": "Turbo Track Time Trial - Unlock N. Tropy",
@@ -2759,11 +2753,11 @@
   {
     "name": "Turbo Track Time Trial - Beat N. Tropy",
     "category": ["Track - Turbo Track", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Turbo Track| and |Turbo Track - Progressive Ghost:1|"
+    "requires": "(|Turbo Track| AND |Turbo Track - N. Tropy|) OR (|Turbo Track| AND {YamlEnabled(option_n_oxide)} AND |Turbo Track - Progressive Ghost:1|})"
   },
   {
     "name": "Turbo Track Time Trial - Beat N. Oxide",
     "category": ["Track - Turbo Track", "Classic", "Time Trial_option", "N. Oxide"],
-    "requires": "|Turbo Track| and |Turbo Track - Progressive Ghost:2|"
+    "requires": "|Turbo Track| AND |Turbo Track - Progressive Ghost:2|"
   }
 ]

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,10 +1,10 @@
 [
-{
-	"name": "Goal (All Trophies)",
-	"victory": true,
-	"requires": "|Ultimate Trophy (Victory)|",
-	"category": []
-},
+	{
+		"name": "Goal (All Trophies)",
+		"victory": true,
+		"requires": "|Ultimate Trophy (Victory)|",
+		"category": []
+	},
   {
     "name": "Gather 1 Trophy",
     "requires": "|@Trophies:1|",
@@ -2497,8 +2497,8 @@
   },
   {
     "name": "Crash Cove Time Trial - Beat N. Tropy",
-    "category": ["Track - Crash Cove", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Crash Cove| AND |Crash Cove - N. Tropy|) OR (|Crash Cove| AND {YamlEnabled(option_n_oxide)} AND |Crash Cove - Progressive Ghost:1|})"
+    "category": ["Track - Crash Cove", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Crash Cove| AND (|Crash Cove - N. Tropy| OR |Crash Cove - Progressive Ghost:1|)"
   },
   {
     "name": "Crash Cove Time Trial - Beat N. Oxide",
@@ -2512,8 +2512,8 @@
   },
   {
     "name": "Roo's Tubes Time Trial - Beat N. Tropy",
-    "category": ["Track - Roo's Tubes", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Roo's Tubes| AND |Roo's Tubes - N. Tropy|) OR (|Roo's Tubes| AND {YamlEnabled(option_n_oxide)} AND |Roo's Tubes - Progressive Ghost:1|})"
+    "category": ["Track - Roo's Tubes", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Roo's Tubes| AND (|Roo's Tubes - N. Tropy| OR |Roo's Tubes - Progressive Ghost:1|)"
   },
   {
     "name": "Roo's Tubes Time Trial - Beat N. Oxide",
@@ -2527,8 +2527,8 @@
   },
   {
     "name": "Mystery Caves Time Trial - Beat N. Tropy",
-    "category": ["Track - Mystery Caves", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "|Mystery Caves| AND |Mystery Caves - N. Tropy|) OR (|Mystery Caves| AND {YamlEnabled(option_n_oxide)} AND |Mystery Caves - Progressive Ghost:1|})"
+    "category": ["Track - Mystery Caves", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Mystery Caves| AND (|Mystery Caves - N. Tropy| OR |Mystery Caves - Progressive Ghost:1|)"
   },
   {
     "name": "Mystery Caves Time Trial - Beat N. Oxide",
@@ -2542,8 +2542,8 @@
   },
   {
     "name": "Sewer Speedway Time Trial - Beat N. Tropy",
-    "category": ["Track - Sewer Speedway", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Sewer Speedway| AND |Sewer Speedway - N. Tropy|) OR (|Sewer Speedway| AND {YamlEnabled(option_n_oxide)} AND |Sewer Speedway - Progressive Ghost:1|})"
+    "category": ["Track - Sewer Speedway", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Sewer Speedway| AND (|Sewer Speedway - N. Tropy| OR |Sewer Speedway - Progressive Ghost:1|)"
   },
   {
     "name": "Sewer Speedway Time Trial - Beat N. Oxide",
@@ -2557,8 +2557,8 @@
   },
   {
     "name": "Coco Park Time Trial - Beat N. Tropy",
-    "category": ["Track - Coco Park", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Coco Park| AND |Coco Park - N. Tropy|) OR (|Coco Park| AND {YamlEnabled(option_n_oxide)} AND |Coco Park - Progressive Ghost:1|})"
+    "category": ["Track - Coco Park", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Coco Park| AND (|Coco Park - N. Tropy| OR |Coco Park - Progressive Ghost:1|)"
   },
   {
     "name": "Coco Park Time Trial - Beat N. Oxide",
@@ -2572,8 +2572,8 @@
   },
   {
     "name": "Tiger Temple Time Trial - Beat N. Tropy",
-    "category": ["Track - Tiger Temple", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Tiger Temple| AND |Tiger Temple - N. Tropy|) OR (|Tiger Temple| AND {YamlEnabled(option_n_oxide)} AND |Tiger Temple - Progressive Ghost:1|})"
+    "category": ["Track - Tiger Temple", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Tiger Temple| AND (|Tiger Temple - N. Tropy| OR |Tiger Temple - Progressive Ghost:1|)"
   },
   {
     "name": "Tiger Temple Time Trial - Beat N. Oxide",
@@ -2587,8 +2587,8 @@
   },
   {
     "name": "Papu's Pyramid Time Trial - Beat N. Tropy",
-    "category": ["Track - Papu's Pyramid", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Papu's Pyramid| AND |Papu's Pyramid - N. Tropy|) OR (|Papu's Pyramid| AND {YamlEnabled(option_n_oxide)} AND |Papu's Pyramid - Progressive Ghost:1|})"
+    "category": ["Track - Papu's Pyramid", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Papu's Pyramid| AND (|Papu's Pyramid - N. Tropy| OR |Papu's Pyramid - Progressive Ghost:1|)"
   },
   {
     "name": "Papu's Pyramid Time Trial - Beat N. Oxide",
@@ -2602,8 +2602,8 @@
   },
   {
     "name": "Dingo Canyon Time Trial - Beat N. Tropy",
-    "category": ["Track - Dingo Canyon", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Dingo Canyon| AND |Dingo Canyon - N. Tropy|) OR (|Dingo Canyon| AND {YamlEnabled(option_n_oxide)} AND |Dingo Canyon - Progressive Ghost:1|})"
+    "category": ["Track - Dingo Canyon", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Dingo Canyon| AND (|Dingo Canyon - N. Tropy| OR |Dingo Canyon - Progressive Ghost:1|)"
   },
   {
     "name": "Dingo Canyon Time Trial - Beat N. Oxide",
@@ -2617,8 +2617,8 @@
   },
   {
     "name": "Blizzard Bluff Time Trial - Beat N. Tropy",
-    "category": ["Track - Blizzard Bluff", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Blizzard Bluff| AND |Blizzard Bluff - N. Tropy|) OR (|Blizzard Bluff| AND {YamlEnabled(option_n_oxide)} AND |Blizzard Bluff - Progressive Ghost:1|})"
+    "category": ["Track - Blizzard Bluff", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Blizzard Bluff| AND (|Blizzard Bluff - N. Tropy| OR |Blizzard Bluff - Progressive Ghost:1|)"
   },
   {
     "name": "Blizzard Bluff Time Trial - Beat N. Oxide",
@@ -2632,8 +2632,8 @@
   },
   {
     "name": "Dragon Mines Time Trial - Beat N. Tropy",
-    "category": ["Track - Dragon Mines", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Dragon Mines| AND |Dragon Mines - N. Tropy|) OR (|Dragon Mines| AND {YamlEnabled(option_n_oxide)} AND |Dragon Mines - Progressive Ghost:1|})"
+    "category": ["Track - Dragon Mines", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Dragon Mines| AND (|Dragon Mines - N. Tropy| OR |Dragon Mines - Progressive Ghost:1|)"
   },
   {
     "name": "Dragon Mines Time Trial - Beat N. Oxide",
@@ -2647,8 +2647,8 @@
   },
   {
     "name": "Polar Pass Time Trial - Beat N. Tropy",
-    "category": ["Track - Polar Pass", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Polar Pass| AND |Polar Pass - N. Tropy|) OR (|Polar Pass| AND {YamlEnabled(option_n_oxide)} AND |Polar Pass - Progressive Ghost:1|})"
+    "category": ["Track - Polar Pass", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Polar Pass| AND (|Polar Pass - N. Tropy| OR |Polar Pass - Progressive Ghost:1|)"
   },
   {
     "name": "Polar Pass Time Trial - Beat N. Oxide",
@@ -2662,8 +2662,8 @@
   },
   {
     "name": "Tiny Arena Time Trial - Beat N. Tropy",
-    "category": ["Track - Tiny Arena", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Tiny Arena| AND |Tiny Arena - N. Tropy|) OR (|Tiny Arena| AND {YamlEnabled(option_n_oxide)} AND |Tiny Arena - Progressive Ghost:1|})"
+    "category": ["Track - Tiny Arena", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Tiny Arena| AND (|Tiny Arena - N. Tropy| OR |Tiny Arena - Progressive Ghost:1|)"
   },
   {
     "name": "Tiny Arena Time Trial - Beat N. Oxide",
@@ -2677,8 +2677,8 @@
   },
   {
     "name": "N. Gin Labs Time Trial - Beat N. Tropy",
-    "category": ["Track - N. Gin Labs", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|N. Gin Labs| AND |N. Gin Labs - N. Tropy|) OR (|N. Gin Labs| AND {YamlEnabled(option_n_oxide)} AND |N. Gin Labs - Progressive Ghost:1|})"
+    "category": ["Track - N. Gin Labs", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|N. Gin Labs| AND (|N. Gin Labs - N. Tropy| OR |N. Gin Labs - Progressive Ghost:1|)"
   },
   {
     "name": "N. Gin Labs Time Trial - Beat N. Oxide",
@@ -2692,8 +2692,8 @@
   },
   {
     "name": "Cortex Castle Time Trial - Beat N. Tropy",
-    "category": ["Track - Cortex Castle", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Cortex Castle| AND |Cortex Castle - N. Tropy|) OR (|Cortex Castle| AND {YamlEnabled(option_n_oxide)} AND |Cortex Castle - Progressive Ghost:1|})"
+    "category": ["Track - Cortex Castle", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Cortex Castle| AND (|Cortex Castle - N. Tropy| OR |Cortex Castle - Progressive Ghost:1|)"
   },
   {
     "name": "Cortex Castle Time Trial - Beat N. Oxide",
@@ -2707,8 +2707,8 @@
   },
   {
     "name": "Hot Air Skyway Time Trial - Beat N. Tropy",
-    "category": ["Track - Hot Air Skyway", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Hot Air Skyway| AND |Hot Air Skyway - N. Tropy|) OR (|Hot Air Skyway| AND {YamlEnabled(option_n_oxide)} AND |Hot Air Skyway - Progressive Ghost:1|})"
+    "category": ["Track - Hot Air Skyway", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Hot Air Skyway| AND (|Hot Air Skyway - N. Tropy| OR |Hot Air Skyway - Progressive Ghost:1|)"
   },
   {
     "name": "Hot Air Skyway Time Trial - Beat N. Oxide",
@@ -2722,8 +2722,8 @@
   },
   {
     "name": "Oxide Station Time Trial - Beat N. Tropy",
-    "category": ["Track - Oxide Station", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Oxide Station| AND |Oxide Station - N. Tropy|) OR (|Oxide Station| AND {YamlEnabled(option_n_oxide)} AND |Oxide Station - Progressive Ghost:1|})"
+    "category": ["Track - Oxide Station", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Oxide Station| AND (|Oxide Station - N. Tropy| OR |Oxide Station - Progressive Ghost:1|)"
   },
   {
     "name": "Oxide Station Time Trial - Beat N. Oxide",
@@ -2737,8 +2737,8 @@
   },
   {
     "name": "Slide Coliseum Time Trial - Beat N. Tropy",
-    "category": ["Track - Slide Coliseum", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Slide Coliseum| AND |Slide Coliseum - N. Tropy|) OR (|Slide Coliseum| AND {YamlEnabled(option_n_oxide)} AND |Slide Coliseum - Progressive Ghost:1|})"
+    "category": ["Track - Slide Coliseum", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Slide Coliseum| AND (|Slide Coliseum - N. Tropy| OR |Slide Coliseum - Progressive Ghost:1|)"
   },
   {
     "name": "Slide Coliseum Time Trial - Beat N. Oxide",
@@ -2752,8 +2752,8 @@
   },
   {
     "name": "Turbo Track Time Trial - Beat N. Tropy",
-    "category": ["Track - Turbo Track", "Classic", "Time Trial_option", "N. Tropy"],
-    "requires": "(|Turbo Track| AND |Turbo Track - N. Tropy|) OR (|Turbo Track| AND {YamlEnabled(option_n_oxide)} AND |Turbo Track - Progressive Ghost:1|})"
+    "category": ["Track - Turbo Track", "Classic", "Time Trial_option", "N. Tropy Loc"],
+    "requires": "|Turbo Track| AND (|Turbo Track - N. Tropy| OR |Turbo Track - Progressive Ghost:1|)"
   },
   {
     "name": "Turbo Track Time Trial - Beat N. Oxide",

--- a/hooks/Helpers.py
+++ b/hooks/Helpers.py
@@ -55,6 +55,18 @@ def before_is_category_enabled(multiworld: MultiWorld, player: int, category_nam
             if Helpers.get_option_value(multiworld, player, "included_ghosts") >= 2:
                 return True
         return False
+    if category_name == "Characters" or category_name == "Unlockable":
+        selection = Helpers.get_option_value(multiworld, player, "character_rando")
+        if category_name == "Characters":
+            if selection == 1 or selection == 2:
+                return True
+            else:
+                return False
+        if category_name == "Unlockable":
+            if selection == 2:
+                return True
+            else:
+                return False
             
     return None
 

--- a/hooks/Helpers.py
+++ b/hooks/Helpers.py
@@ -47,12 +47,17 @@ def before_is_category_enabled(multiworld: MultiWorld, player: int, category_nam
             return False
     if category_name == "N. Tropy":
         if Helpers.get_option_value(multiworld, player, "include_time_trial") == 1:
+            if Helpers.get_option_value(multiworld, player, "included_ghosts") == 1:
+                return True
+        return False
+    if category_name == "N. Tropy Loc":
+        if Helpers.get_option_value(multiworld, player, "include_time_trial") == 1:
             if Helpers.get_option_value(multiworld, player, "included_ghosts") >= 1:
                 return True
         return False
     if category_name == "N. Oxide":
         if Helpers.get_option_value(multiworld, player, "include_time_trial") == 1:
-            if Helpers.get_option_value(multiworld, player, "included_ghosts") >= 2:
+            if Helpers.get_option_value(multiworld, player, "included_ghosts") == 2:
                 return True
         return False
     if category_name == "Characters" or category_name == "Unlockable":

--- a/hooks/Options.py
+++ b/hooks/Options.py
@@ -111,7 +111,17 @@ class percentage_trophies(Range):
     range_start = 1
     range_end = 100
     default = 80
-
+    
+class Character_Rando(Choice):
+    """
+    Characters are randomized based on which racer you want to be. Disabling this allows all characters to be played.
+    """
+    display_name = "Randomize Characters"
+    option_false = 0
+    option_starter = 1
+    option_unlockable = 2
+    default = 1
+    
 # This is called before any manual options are defined, in case you want to define your own with a clean slate or let Manual define over them
 def before_options_defined(options: dict) -> dict:
     options["percentage_trophies"] = percentage_trophies
@@ -121,6 +131,7 @@ def before_options_defined(options: dict) -> dict:
     options["cups_unlock_method"] = cups_unlock_method
     options["include_time_trial"] = include_time_trial
     options["included_ghosts"] = included_ghosts
+    options["character_rando"] = Character_Rando
     return options
 
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options

--- a/hooks/Options.py
+++ b/hooks/Options.py
@@ -112,14 +112,17 @@ class percentage_trophies(Range):
     range_end = 100
     default = 80
     
-class Character_Rando(Choice):
+class character_rando(Choice):
     """
-    Characters are randomized based on which racer you want to be. Disabling this allows all characters to be played.
+    Characters are added into the item pool as filler. Depending on other settings, not all randomized characters may be available in a given seed.
+    None: All characters are playable as the player chooses.
+    Starter: The starter characters are randomized. Unlockable characters are not playable in this option.
+    All Characters: All characters are randomized.
     """
     display_name = "Randomize Characters"
-    option_false = 0
+    option_none = 0
     option_starter = 1
-    option_unlockable = 2
+    option_all_characters = 2
     default = 1
     
 # This is called before any manual options are defined, in case you want to define your own with a clean slate or let Manual define over them
@@ -131,7 +134,7 @@ def before_options_defined(options: dict) -> dict:
     options["cups_unlock_method"] = cups_unlock_method
     options["include_time_trial"] = include_time_trial
     options["included_ghosts"] = included_ghosts
-    options["character_rando"] = Character_Rando
+    options["character_rando"] = character_rando
     return options
 
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options


### PR DESCRIPTION
- Removed location for Starting track and is now randomized via game.json for characters and tracks.
+ Option to enable between starting, unlockables (with starting), or none.
+ Made Progressive Ghost available only if you enable N. Oxide in Time Trials. Reimplemented N. Tropy for only n. tropy enabled
* Currently experimental Progressive Ghost/N. Tropy. I don't know what the yamlenabled name is for enabling n. oxide is called. Please change "option_n_oxide" to something else please before pushing out this pr.