### PR TITLE
Remove Ultimate Trophy feature

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -12,11 +12,10 @@ class FillerTrapPercent(Range):
 
 manual_options = before_options_defined({})
 
-if len(victory_names) > 1:
-    pass
-    goal = {'option_' + v: i for i, v in enumerate(victory_names)}
-    manual_options['goal'] = type('goal', (Choice,), goal)
-    manual_options['goal'].__doc__ = "Choose your victory condition."
+#if len(victory_names) > 1:
+    #goal = {'option_' + v: i for i, v in enumerate(victory_names)}
+    #manual_options['goal'] = type('goal', (Choice,), goal)
+    #manual_options['goal'].__doc__ = "Choose your victory condition."
 
 if any(item.get('trap') for item in item_table):
     manual_options["filler_traps"] = FillerTrapPercent

--- a/Options.py
+++ b/Options.py
@@ -13,6 +13,7 @@ class FillerTrapPercent(Range):
 manual_options = before_options_defined({})
 
 if len(victory_names) > 1:
+    pass
     goal = {'option_' + v: i for i, v in enumerate(victory_names)}
     manual_options['goal'] = type('goal', (Choice,), goal)
     manual_options['goal'].__doc__ = "Choose your victory condition."

--- a/Options.py
+++ b/Options.py
@@ -12,10 +12,10 @@ class FillerTrapPercent(Range):
 
 manual_options = before_options_defined({})
 
-#if len(victory_names) > 1:
-    #goal = {'option_' + v: i for i, v in enumerate(victory_names)}
-    #manual_options['goal'] = type('goal', (Choice,), goal)
-    #manual_options['goal'].__doc__ = "Choose your victory condition."
+if len(victory_names) > 1:
+    goal = {'option_' + v: i for i, v in enumerate(victory_names)}
+    manual_options['goal'] = type('goal', (Choice,), goal)
+    manual_options['goal'].__doc__ = "Choose your victory condition."
 
 if any(item.get('trap') for item in item_table):
     manual_options["filler_traps"] = FillerTrapPercent

--- a/data/items.json
+++ b/data/items.json
@@ -1,11 +1,5 @@
 [
 	{
-		"count":1,
-		"name": "Ultimate Trophy (Victory)",
-		"category": ["Win_Condition"],
-		"progression": true
-	},
-	{
 		"count":300,
 		"name": "Trophy",
 		"category": ["Trophies", "Classic"],

--- a/data/items.json
+++ b/data/items.json
@@ -1,6 +1,6 @@
 [
 	{
-		"count":172,
+		"count":173,
 		"name": "Trophy",
 		"category": ["Trophies", "Classic"],
 		"progression": true

--- a/data/items.json
+++ b/data/items.json
@@ -1,6 +1,6 @@
 [
 	{
-		"count":300,
+		"count":172,
 		"name": "Trophy",
 		"category": ["Trophies", "Classic"],
 		"progression": true

--- a/data/locations.json
+++ b/data/locations.json
@@ -1,1503 +1,1034 @@
 [
-	{
-		"name": "Goal (All Trophies)",
-		"victory": true,
-		"requires": "|Ultimate Trophy (Victory)|",
-		"category": []
-	},
   {
     "name": "Gather 1 Trophy",
+	"victory": true,
     "requires": "|@Trophies:1|",
     "category": []
   },
   {
     "name": "Gather 2 Trophies",
+	"victory": true,
     "requires": "|@Trophies:2|",
     "category": []
   },
   {
     "name": "Gather 3 Trophies",
+	"victory": true,
     "requires": "|@Trophies:3|",
     "category": []
   },
   {
     "name": "Gather 4 Trophies",
+	"victory": true,
     "requires": "|@Trophies:4|",
     "category": []
   },
   {
     "name": "Gather 5 Trophies",
+	"victory": true,
     "requires": "|@Trophies:5|",
     "category": []
   },
   {
     "name": "Gather 6 Trophies",
+	"victory": true,
     "requires": "|@Trophies:6|",
     "category": []
   },
   {
     "name": "Gather 7 Trophies",
+	"victory": true,
     "requires": "|@Trophies:7|",
     "category": []
   },
   {
     "name": "Gather 8 Trophies",
+	"victory": true,
     "requires": "|@Trophies:8|",
     "category": []
   },
   {
     "name": "Gather 9 Trophies",
+	"victory": true,
     "requires": "|@Trophies:9|",
     "category": []
   },
   {
     "name": "Gather 10 Trophies",
+	"victory": true,
     "requires": "|@Trophies:10|",
     "category": []
   },
   {
     "name": "Gather 11 Trophies",
+	"victory": true,
     "requires": "|@Trophies:11|",
     "category": []
   },
   {
     "name": "Gather 12 Trophies",
+	"victory": true,
     "requires": "|@Trophies:12|",
     "category": []
   },
   {
     "name": "Gather 13 Trophies",
+	"victory": true,
     "requires": "|@Trophies:13|",
     "category": []
   },
   {
     "name": "Gather 14 Trophies",
+	"victory": true,
     "requires": "|@Trophies:14|",
     "category": []
   },
   {
     "name": "Gather 15 Trophies",
+	"victory": true,
     "requires": "|@Trophies:15|",
     "category": []
   },
   {
     "name": "Gather 16 Trophies",
+	"victory": true,
     "requires": "|@Trophies:16|",
     "category": []
   },
   {
     "name": "Gather 17 Trophies",
+	"victory": true,
     "requires": "|@Trophies:17|",
     "category": []
   },
   {
     "name": "Gather 18 Trophies",
+	"victory": true,
     "requires": "|@Trophies:18|",
     "category": []
   },
   {
     "name": "Gather 19 Trophies",
+	"victory": true,
     "requires": "|@Trophies:19|",
     "category": []
   },
   {
     "name": "Gather 20 Trophies",
+	"victory": true,
     "requires": "|@Trophies:20|",
     "category": []
   },
   {
     "name": "Gather 21 Trophies",
+	"victory": true,
     "requires": "|@Trophies:21|",
     "category": []
   },
   {
     "name": "Gather 22 Trophies",
+	"victory": true,
     "requires": "|@Trophies:22|",
     "category": []
   },
   {
     "name": "Gather 23 Trophies",
+	"victory": true,
     "requires": "|@Trophies:23|",
     "category": []
   },
   {
     "name": "Gather 24 Trophies",
+	"victory": true,
     "requires": "|@Trophies:24|",
     "category": []
   },
   {
     "name": "Gather 25 Trophies",
+	"victory": true,
     "requires": "|@Trophies:25|",
     "category": []
   },
   {
     "name": "Gather 26 Trophies",
+	"victory": true,
     "requires": "|@Trophies:26|",
     "category": []
   },
   {
     "name": "Gather 27 Trophies",
+	"victory": true,
     "requires": "|@Trophies:27|",
     "category": []
   },
   {
     "name": "Gather 28 Trophies",
+	"victory": true,
     "requires": "|@Trophies:28|",
     "category": []
   },
   {
     "name": "Gather 29 Trophies",
+	"victory": true,
     "requires": "|@Trophies:29|",
     "category": []
   },
   {
     "name": "Gather 30 Trophies",
+	"victory": true,
     "requires": "|@Trophies:30|",
     "category": []
   },
   {
     "name": "Gather 31 Trophies",
+	"victory": true,
     "requires": "|@Trophies:31|",
     "category": []
   },
   {
     "name": "Gather 32 Trophies",
+	"victory": true,
     "requires": "|@Trophies:32|",
     "category": []
   },
   {
     "name": "Gather 33 Trophies",
+	"victory": true,
     "requires": "|@Trophies:33|",
     "category": []
   },
   {
     "name": "Gather 34 Trophies",
+	"victory": true,
     "requires": "|@Trophies:34|",
     "category": []
   },
   {
     "name": "Gather 35 Trophies",
+	"victory": true,
     "requires": "|@Trophies:35|",
     "category": []
   },
   {
     "name": "Gather 36 Trophies",
+	"victory": true,
     "requires": "|@Trophies:36|",
     "category": []
   },
   {
     "name": "Gather 37 Trophies",
+	"victory": true,
     "requires": "|@Trophies:37|",
     "category": []
   },
   {
     "name": "Gather 38 Trophies",
+	"victory": true,
     "requires": "|@Trophies:38|",
     "category": []
   },
   {
     "name": "Gather 39 Trophies",
+	"victory": true,
     "requires": "|@Trophies:39|",
     "category": []
   },
   {
     "name": "Gather 40 Trophies",
+	"victory": true,
     "requires": "|@Trophies:40|",
     "category": []
   },
   {
     "name": "Gather 41 Trophies",
+	"victory": true,
     "requires": "|@Trophies:41|",
     "category": []
   },
   {
     "name": "Gather 42 Trophies",
+	"victory": true,
     "requires": "|@Trophies:42|",
     "category": []
   },
   {
     "name": "Gather 43 Trophies",
+	"victory": true,
     "requires": "|@Trophies:43|",
     "category": []
   },
   {
     "name": "Gather 44 Trophies",
+	"victory": true,
     "requires": "|@Trophies:44|",
     "category": []
   },
   {
     "name": "Gather 45 Trophies",
+	"victory": true,
     "requires": "|@Trophies:45|",
     "category": []
   },
   {
     "name": "Gather 46 Trophies",
+	"victory": true,
     "requires": "|@Trophies:46|",
     "category": []
   },
   {
     "name": "Gather 47 Trophies",
+	"victory": true,
     "requires": "|@Trophies:47|",
     "category": []
   },
   {
     "name": "Gather 48 Trophies",
+	"victory": true,
     "requires": "|@Trophies:48|",
     "category": []
   },
   {
     "name": "Gather 49 Trophies",
+	"victory": true,
     "requires": "|@Trophies:49|",
     "category": []
   },
   {
     "name": "Gather 50 Trophies",
+	"victory": true,
     "requires": "|@Trophies:50|",
     "category": []
   },
   {
     "name": "Gather 51 Trophies",
+	"victory": true,
     "requires": "|@Trophies:51|",
     "category": []
   },
   {
     "name": "Gather 52 Trophies",
+	"victory": true,
     "requires": "|@Trophies:52|",
     "category": []
   },
   {
     "name": "Gather 53 Trophies",
+	"victory": true,
     "requires": "|@Trophies:53|",
     "category": []
   },
   {
     "name": "Gather 54 Trophies",
+	"victory": true,
     "requires": "|@Trophies:54|",
     "category": []
   },
   {
     "name": "Gather 55 Trophies",
+	"victory": true,
     "requires": "|@Trophies:55|",
     "category": []
   },
   {
     "name": "Gather 56 Trophies",
+	"victory": true,
     "requires": "|@Trophies:56|",
     "category": []
   },
   {
     "name": "Gather 57 Trophies",
+	"victory": true,
     "requires": "|@Trophies:57|",
     "category": []
   },
   {
     "name": "Gather 58 Trophies",
+	"victory": true,
     "requires": "|@Trophies:58|",
     "category": []
   },
   {
     "name": "Gather 59 Trophies",
+	"victory": true,
     "requires": "|@Trophies:59|",
     "category": []
   },
   {
     "name": "Gather 60 Trophies",
+	"victory": true,
     "requires": "|@Trophies:60|",
     "category": []
   },
   {
     "name": "Gather 61 Trophies",
+	"victory": true,
     "requires": "|@Trophies:61|",
     "category": []
   },
   {
     "name": "Gather 62 Trophies",
+	"victory": true,
     "requires": "|@Trophies:62|",
     "category": []
   },
   {
     "name": "Gather 63 Trophies",
+	"victory": true,
     "requires": "|@Trophies:63|",
     "category": []
   },
   {
     "name": "Gather 64 Trophies",
+	"victory": true,
     "requires": "|@Trophies:64|",
     "category": []
   },
   {
     "name": "Gather 65 Trophies",
+	"victory": true,
     "requires": "|@Trophies:65|",
     "category": []
   },
   {
     "name": "Gather 66 Trophies",
+	"victory": true,
     "requires": "|@Trophies:66|",
     "category": []
   },
   {
     "name": "Gather 67 Trophies",
+	"victory": true,
     "requires": "|@Trophies:67|",
     "category": []
   },
   {
     "name": "Gather 68 Trophies",
+	"victory": true,
     "requires": "|@Trophies:68|",
     "category": []
   },
   {
     "name": "Gather 69 Trophies",
+	"victory": true,
     "requires": "|@Trophies:69|",
     "category": []
   },
   {
     "name": "Gather 70 Trophies",
+	"victory": true,
     "requires": "|@Trophies:70|",
     "category": []
   },
   {
     "name": "Gather 71 Trophies",
+	"victory": true,
     "requires": "|@Trophies:71|",
     "category": []
   },
   {
     "name": "Gather 72 Trophies",
+	"victory": true,
     "requires": "|@Trophies:72|",
     "category": []
   },
   {
     "name": "Gather 73 Trophies",
+	"victory": true,
     "requires": "|@Trophies:73|",
     "category": []
   },
   {
     "name": "Gather 74 Trophies",
+	"victory": true,
     "requires": "|@Trophies:74|",
     "category": []
   },
   {
     "name": "Gather 75 Trophies",
+	"victory": true,
     "requires": "|@Trophies:75|",
     "category": []
   },
   {
     "name": "Gather 76 Trophies",
+	"victory": true,
     "requires": "|@Trophies:76|",
     "category": []
   },
   {
     "name": "Gather 77 Trophies",
+	"victory": true,
     "requires": "|@Trophies:77|",
     "category": []
   },
   {
     "name": "Gather 78 Trophies",
+	"victory": true,
     "requires": "|@Trophies:78|",
     "category": []
   },
   {
     "name": "Gather 79 Trophies",
+	"victory": true,
     "requires": "|@Trophies:79|",
     "category": []
   },
   {
     "name": "Gather 80 Trophies",
+	"victory": true,
     "requires": "|@Trophies:80|",
     "category": []
   },
   {
     "name": "Gather 81 Trophies",
+	"victory": true,
     "requires": "|@Trophies:81|",
     "category": []
   },
   {
     "name": "Gather 82 Trophies",
+	"victory": true,
     "requires": "|@Trophies:82|",
     "category": []
   },
   {
     "name": "Gather 83 Trophies",
+	"victory": true,
     "requires": "|@Trophies:83|",
     "category": []
   },
   {
     "name": "Gather 84 Trophies",
+	"victory": true,
     "requires": "|@Trophies:84|",
     "category": []
   },
   {
     "name": "Gather 85 Trophies",
+	"victory": true,
     "requires": "|@Trophies:85|",
     "category": []
   },
   {
     "name": "Gather 86 Trophies",
+	"victory": true,
     "requires": "|@Trophies:86|",
     "category": []
   },
   {
     "name": "Gather 87 Trophies",
+	"victory": true,
     "requires": "|@Trophies:87|",
     "category": []
   },
   {
     "name": "Gather 88 Trophies",
+	"victory": true,
     "requires": "|@Trophies:88|",
     "category": []
   },
   {
     "name": "Gather 89 Trophies",
+	"victory": true, 
     "requires": "|@Trophies:89|",
     "category": []
   },
   {
     "name": "Gather 90 Trophies",
+	"victory": true,
     "requires": "|@Trophies:90|",
     "category": []
   },
   {
     "name": "Gather 91 Trophies",
+	"victory": true,
     "requires": "|@Trophies:91|",
     "category": []
   },
   {
     "name": "Gather 92 Trophies",
+	"victory": true,
     "requires": "|@Trophies:92|",
     "category": []
   },
   {
     "name": "Gather 93 Trophies",
+	"victory": true,
     "requires": "|@Trophies:93|",
     "category": []
   },
   {
     "name": "Gather 94 Trophies",
+	"victory": true,
     "requires": "|@Trophies:94|",
     "category": []
   },
   {
     "name": "Gather 95 Trophies",
+	"victory": true,
     "requires": "|@Trophies:95|",
     "category": []
   },
   {
     "name": "Gather 96 Trophies",
+	"victory": true,
     "requires": "|@Trophies:96|",
     "category": []
   },
   {
     "name": "Gather 97 Trophies",
+	"victory": true,
     "requires": "|@Trophies:97|",
     "category": []
   },
   {
     "name": "Gather 98 Trophies",
+	"victory": true,
     "requires": "|@Trophies:98|",
     "category": []
   },
   {
     "name": "Gather 99 Trophies",
+	"victory": true,
     "requires": "|@Trophies:99|",
     "category": []
   },
   {
     "name": "Gather 100 Trophies",
+	"victory": true,
     "requires": "|@Trophies:100|",
     "category": []
   },
   {
     "name": "Gather 101 Trophies",
+	"victory": true,
     "requires": "|@Trophies:101|",
     "category": []
   },
   {
     "name": "Gather 102 Trophies",
+	"victory": true,
     "requires": "|@Trophies:102|",
     "category": []
   },
   {
     "name": "Gather 103 Trophies",
+	"victory": true,
     "requires": "|@Trophies:103|",
     "category": []
   },
   {
     "name": "Gather 104 Trophies",
+	"victory": true,
     "requires": "|@Trophies:104|",
     "category": []
   },
   {
     "name": "Gather 105 Trophies",
+	"victory": true,
     "requires": "|@Trophies:105|",
     "category": []
   },
   {
     "name": "Gather 106 Trophies",
+	"victory": true,
     "requires": "|@Trophies:106|",
     "category": []
   },
   {
     "name": "Gather 107 Trophies",
+	"victory": true,
     "requires": "|@Trophies:107|",
     "category": []
   },
   {
     "name": "Gather 108 Trophies",
+	"victory": true,
     "requires": "|@Trophies:108|",
     "category": []
   },
   {
     "name": "Gather 109 Trophies",
+	"victory": true,
     "requires": "|@Trophies:109|",
     "category": []
   },
   {
     "name": "Gather 110 Trophies",
+	"victory": true,
     "requires": "|@Trophies:110|",
     "category": []
   },
   {
     "name": "Gather 111 Trophies",
+	"victory": true,
     "requires": "|@Trophies:111|",
     "category": []
   },
   {
     "name": "Gather 112 Trophies",
+	"victory": true,
     "requires": "|@Trophies:112|",
     "category": []
   },
   {
     "name": "Gather 113 Trophies",
+	"victory": true,
     "requires": "|@Trophies:113|",
     "category": []
   },
   {
     "name": "Gather 114 Trophies",
+	"victory": true,
     "requires": "|@Trophies:114|",
     "category": []
   },
   {
     "name": "Gather 115 Trophies",
+	"victory": true,
     "requires": "|@Trophies:115|",
     "category": []
   },
   {
     "name": "Gather 116 Trophies",
+	"victory": true,
     "requires": "|@Trophies:116|",
     "category": []
   },
   {
     "name": "Gather 117 Trophies",
+	"victory": true,
     "requires": "|@Trophies:117|",
     "category": []
   },
   {
     "name": "Gather 118 Trophies",
+	"victory": true,
     "requires": "|@Trophies:118|",
     "category": []
   },
   {
     "name": "Gather 119 Trophies",
+	"victory": true,
     "requires": "|@Trophies:119|",
     "category": []
   },
   {
     "name": "Gather 120 Trophies",
+	"victory": true,
     "requires": "|@Trophies:120|",
     "category": []
   },
   {
     "name": "Gather 121 Trophies",
+	"victory": true,
     "requires": "|@Trophies:121|",
     "category": []
   },
   {
     "name": "Gather 122 Trophies",
+	"victory": true,
     "requires": "|@Trophies:122|",
     "category": []
   },
   {
     "name": "Gather 123 Trophies",
+	"victory": true,
     "requires": "|@Trophies:123|",
     "category": []
   },
   {
     "name": "Gather 124 Trophies",
+	"victory": true,
     "requires": "|@Trophies:124|",
     "category": []
   },
   {
     "name": "Gather 125 Trophies",
+	"victory": true,
     "requires": "|@Trophies:125|",
     "category": []
   },
   {
     "name": "Gather 126 Trophies",
+	"victory": true,
     "requires": "|@Trophies:126|",
     "category": []
   },
   {
     "name": "Gather 127 Trophies",
+	"victory": true,
     "requires": "|@Trophies:127|",
     "category": []
   },
   {
     "name": "Gather 128 Trophies",
+	"victory": true,
     "requires": "|@Trophies:128|",
     "category": []
   },
   {
     "name": "Gather 129 Trophies",
+	"victory": true,
     "requires": "|@Trophies:129|",
     "category": []
   },
   {
     "name": "Gather 130 Trophies",
+	"victory": true,
     "requires": "|@Trophies:130|",
     "category": []
   },
   {
     "name": "Gather 131 Trophies",
+	"victory": true,
     "requires": "|@Trophies:131|",
     "category": []
   },
   {
     "name": "Gather 132 Trophies",
+	"victory": true,
     "requires": "|@Trophies:132|",
     "category": []
   },
   {
     "name": "Gather 133 Trophies",
+	"victory": true,
     "requires": "|@Trophies:133|",
     "category": []
   },
   {
     "name": "Gather 134 Trophies",
+	"victory": true,
     "requires": "|@Trophies:134|",
     "category": []
   },
   {
     "name": "Gather 135 Trophies",
+	"victory": true,
     "requires": "|@Trophies:135|",
     "category": []
   },
   {
     "name": "Gather 136 Trophies",
+	"victory": true,
     "requires": "|@Trophies:136|",
     "category": []
   },
   {
     "name": "Gather 137 Trophies",
+	"victory": true,
     "requires": "|@Trophies:137|",
     "category": []
   },
   {
     "name": "Gather 138 Trophies",
+	"victory": true,
     "requires": "|@Trophies:138|",
     "category": []
   },
   {
     "name": "Gather 139 Trophies",
+	"victory": true,
     "requires": "|@Trophies:139|",
     "category": []
   },
   {
     "name": "Gather 140 Trophies",
+	"victory": true,
     "requires": "|@Trophies:140|",
     "category": []
   },
   {
     "name": "Gather 141 Trophies",
+	"victory": true,
     "requires": "|@Trophies:141|",
     "category": []
   },
   {
     "name": "Gather 142 Trophies",
+	"victory": true,
     "requires": "|@Trophies:142|",
     "category": []
   },
   {
     "name": "Gather 143 Trophies",
+	"victory": true,
     "requires": "|@Trophies:143|",
     "category": []
   },
   {
     "name": "Gather 144 Trophies",
+	"victory": true,
     "requires": "|@Trophies:144|",
     "category": []
   },
   {
     "name": "Gather 145 Trophies",
+	"victory": true,
     "requires": "|@Trophies:145|",
     "category": []
   },
   {
     "name": "Gather 146 Trophies",
+	"victory": true,
     "requires": "|@Trophies:146|",
     "category": []
   },
   {
     "name": "Gather 147 Trophies",
+	"victory": true,
     "requires": "|@Trophies:147|",
     "category": []
   },
   {
     "name": "Gather 148 Trophies",
+	"victory": true,
     "requires": "|@Trophies:148|",
     "category": []
   },
   {
     "name": "Gather 149 Trophies",
+	"victory": true,
     "requires": "|@Trophies:149|",
     "category": []
   },
   {
     "name": "Gather 150 Trophies",
+	"victory": true,
     "requires": "|@Trophies:150|",
     "category": []
   },
   {
     "name": "Gather 151 Trophies",
+	"victory": true,
     "requires": "|@Trophies:151|",
     "category": []
   },
   {
     "name": "Gather 152 Trophies",
+	"victory": true,
     "requires": "|@Trophies:152|",
     "category": []
   },
   {
     "name": "Gather 153 Trophies",
+	"victory": true,
     "requires": "|@Trophies:153|",
     "category": []
   },
   {
     "name": "Gather 154 Trophies",
+	"victory": true,
     "requires": "|@Trophies:154|",
     "category": []
   },
   {
     "name": "Gather 155 Trophies",
+	"victory": true,
     "requires": "|@Trophies:155|",
     "category": []
   },
   {
     "name": "Gather 156 Trophies",
+	"victory": true,
     "requires": "|@Trophies:156|",
     "category": []
   },
   {
     "name": "Gather 157 Trophies",
+	"victory": true,
     "requires": "|@Trophies:157|",
     "category": []
   },
   {
     "name": "Gather 158 Trophies",
+	"victory": true,
     "requires": "|@Trophies:158|",
     "category": []
   },
   {
     "name": "Gather 159 Trophies",
+	"victory": true,
     "requires": "|@Trophies:159|",
     "category": []
   },
   {
     "name": "Gather 160 Trophies",
+	"victory": true,
     "requires": "|@Trophies:160|",
     "category": []
   },
   {
     "name": "Gather 161 Trophies",
+	"victory": true,
     "requires": "|@Trophies:161|",
     "category": []
   },
   {
     "name": "Gather 162 Trophies",
+	"victory": true,
     "requires": "|@Trophies:162|",
     "category": []
   },
   {
     "name": "Gather 163 Trophies",
+	"victory": true,
     "requires": "|@Trophies:163|",
     "category": []
   },
   {
     "name": "Gather 164 Trophies",
+	"victory": true,
     "requires": "|@Trophies:164|",
     "category": []
   },
   {
     "name": "Gather 165 Trophies",
+	"victory": true,
     "requires": "|@Trophies:165|",
     "category": []
   },
   {
     "name": "Gather 166 Trophies",
+	"victory": true,
     "requires": "|@Trophies:166|",
     "category": []
   },
   {
     "name": "Gather 167 Trophies",
+	"victory": true,
     "requires": "|@Trophies:167|",
     "category": []
   },
   {
     "name": "Gather 168 Trophies",
+	"victory": true,
     "requires": "|@Trophies:168|",
     "category": []
   },
   {
     "name": "Gather 169 Trophies",
+	"victory": true,
     "requires": "|@Trophies:169|",
     "category": []
   },
   {
     "name": "Gather 170 Trophies",
+	"victory": true,
     "requires": "|@Trophies:170|",
     "category": []
   },
   {
     "name": "Gather 171 Trophies",
+	"victory": true,
     "requires": "|@Trophies:171|",
     "category": []
   },
   {
     "name": "Gather 172 Trophies",
+	"victory": true,
     "requires": "|@Trophies:172|",
-    "category": []
-  },
-  {
-    "name": "Gather 173 Trophies",
-    "requires": "|@Trophies:173|",
-    "category": []
-  },
-  {
-    "name": "Gather 174 Trophies",
-    "requires": "|@Trophies:174|",
-    "category": []
-  },
-  {
-    "name": "Gather 175 Trophies",
-    "requires": "|@Trophies:175|",
-    "category": []
-  },
-  {
-    "name": "Gather 176 Trophies",
-    "requires": "|@Trophies:176|",
-    "category": []
-  },
-  {
-    "name": "Gather 177 Trophies",
-    "requires": "|@Trophies:177|",
-    "category": []
-  },
-  {
-    "name": "Gather 178 Trophies",
-    "requires": "|@Trophies:178|",
-    "category": []
-  },
-  {
-    "name": "Gather 179 Trophies",
-    "requires": "|@Trophies:179|",
-    "category": []
-  },
-  {
-    "name": "Gather 180 Trophies",
-    "requires": "|@Trophies:180|",
-    "category": []
-  },
-  {
-    "name": "Gather 181 Trophies",
-    "requires": "|@Trophies:181|",
-    "category": []
-  },
-  {
-    "name": "Gather 182 Trophies",
-    "requires": "|@Trophies:182|",
-    "category": []
-  },
-  {
-    "name": "Gather 183 Trophies",
-    "requires": "|@Trophies:183|",
-    "category": []
-  },
-  {
-    "name": "Gather 184 Trophies",
-    "requires": "|@Trophies:184|",
-    "category": []
-  },
-  {
-    "name": "Gather 185 Trophies",
-    "requires": "|@Trophies:185|",
-    "category": []
-  },
-  {
-    "name": "Gather 186 Trophies",
-    "requires": "|@Trophies:186|",
-    "category": []
-  },
-  {
-    "name": "Gather 187 Trophies",
-    "requires": "|@Trophies:187|",
-    "category": []
-  },
-  {
-    "name": "Gather 188 Trophies",
-    "requires": "|@Trophies:188|",
-    "category": []
-  },
-  {
-    "name": "Gather 189 Trophies",
-    "requires": "|@Trophies:189|",
-    "category": []
-  },
-  {
-    "name": "Gather 190 Trophies",
-    "requires": "|@Trophies:190|",
-    "category": []
-  },
-  {
-    "name": "Gather 191 Trophies",
-    "requires": "|@Trophies:191|",
-    "category": []
-  },
-  {
-    "name": "Gather 192 Trophies",
-    "requires": "|@Trophies:192|",
-    "category": []
-  },
-  {
-    "name": "Gather 193 Trophies",
-    "requires": "|@Trophies:193|",
-    "category": []
-  },
-  {
-    "name": "Gather 194 Trophies",
-    "requires": "|@Trophies:194|",
-    "category": []
-  },
-  {
-    "name": "Gather 195 Trophies",
-    "requires": "|@Trophies:195|",
-    "category": []
-  },
-  {
-    "name": "Gather 196 Trophies",
-    "requires": "|@Trophies:196|",
-    "category": []
-  },
-  {
-    "name": "Gather 197 Trophies",
-    "requires": "|@Trophies:197|",
-    "category": []
-  },
-  {
-    "name": "Gather 198 Trophies",
-    "requires": "|@Trophies:198|",
-    "category": []
-  },
-  {
-    "name": "Gather 199 Trophies",
-    "requires": "|@Trophies:199|",
-    "category": []
-  },
-  {
-    "name": "Gather 200 Trophies",
-    "requires": "|@Trophies:200|",
-    "category": []
-  },
-  {
-    "name": "Gather 201 Trophies",
-    "requires": "|@Trophies:201|",
-    "category": []
-  },
-  {
-    "name": "Gather 202 Trophies",
-    "requires": "|@Trophies:202|",
-    "category": []
-  },
-  {
-    "name": "Gather 203 Trophies",
-    "requires": "|@Trophies:203|",
-    "category": []
-  },
-  {
-    "name": "Gather 204 Trophies",
-    "requires": "|@Trophies:204|",
-    "category": []
-  },
-  {
-    "name": "Gather 205 Trophies",
-    "requires": "|@Trophies:205|",
-    "category": []
-  },
-  {
-    "name": "Gather 206 Trophies",
-    "requires": "|@Trophies:206|",
-    "category": []
-  },
-  {
-    "name": "Gather 207 Trophies",
-    "requires": "|@Trophies:207|",
-    "category": []
-  },
-  {
-    "name": "Gather 208 Trophies",
-    "requires": "|@Trophies:208|",
-    "category": []
-  },
-  {
-    "name": "Gather 209 Trophies",
-    "requires": "|@Trophies:209|",
-    "category": []
-  },
-  {
-    "name": "Gather 210 Trophies",
-    "requires": "|@Trophies:210|",
-    "category": []
-  },
-  {
-    "name": "Gather 211 Trophies",
-    "requires": "|@Trophies:211|",
-    "category": []
-  },
-  {
-    "name": "Gather 212 Trophies",
-    "requires": "|@Trophies:212|",
-    "category": []
-  },
-  {
-    "name": "Gather 213 Trophies",
-    "requires": "|@Trophies:213|",
-    "category": []
-  },
-  {
-    "name": "Gather 214 Trophies",
-    "requires": "|@Trophies:214|",
-    "category": []
-  },
-  {
-    "name": "Gather 215 Trophies",
-    "requires": "|@Trophies:215|",
-    "category": []
-  },
-  {
-    "name": "Gather 216 Trophies",
-    "requires": "|@Trophies:216|",
-    "category": []
-  },
-  {
-    "name": "Gather 217 Trophies",
-    "requires": "|@Trophies:217|",
-    "category": []
-  },
-  {
-    "name": "Gather 218 Trophies",
-    "requires": "|@Trophies:218|",
-    "category": []
-  },
-  {
-    "name": "Gather 219 Trophies",
-    "requires": "|@Trophies:219|",
-    "category": []
-  },
-  {
-    "name": "Gather 220 Trophies",
-    "requires": "|@Trophies:220|",
-    "category": []
-  },
-  {
-    "name": "Gather 221 Trophies",
-    "requires": "|@Trophies:221|",
-    "category": []
-  },
-  {
-    "name": "Gather 222 Trophies",
-    "requires": "|@Trophies:222|",
-    "category": []
-  },
-  {
-    "name": "Gather 223 Trophies",
-    "requires": "|@Trophies:223|",
-    "category": []
-  },
-  {
-    "name": "Gather 224 Trophies",
-    "requires": "|@Trophies:224|",
-    "category": []
-  },
-  {
-    "name": "Gather 225 Trophies",
-    "requires": "|@Trophies:225|",
-    "category": []
-  },
-  {
-    "name": "Gather 226 Trophies",
-    "requires": "|@Trophies:226|",
-    "category": []
-  },
-  {
-    "name": "Gather 227 Trophies",
-    "requires": "|@Trophies:227|",
-    "category": []
-  },
-  {
-    "name": "Gather 228 Trophies",
-    "requires": "|@Trophies:228|",
-    "category": []
-  },
-  {
-    "name": "Gather 229 Trophies",
-    "requires": "|@Trophies:229|",
-    "category": []
-  },
-  {
-    "name": "Gather 230 Trophies",
-    "requires": "|@Trophies:230|",
-    "category": []
-  },
-  {
-    "name": "Gather 231 Trophies",
-    "requires": "|@Trophies:231|",
-    "category": []
-  },
-  {
-    "name": "Gather 232 Trophies",
-    "requires": "|@Trophies:232|",
-    "category": []
-  },
-  {
-    "name": "Gather 233 Trophies",
-    "requires": "|@Trophies:233|",
-    "category": []
-  },
-  {
-    "name": "Gather 234 Trophies",
-    "requires": "|@Trophies:234|",
-    "category": []
-  },
-  {
-    "name": "Gather 235 Trophies",
-    "requires": "|@Trophies:235|",
-    "category": []
-  },
-  {
-    "name": "Gather 236 Trophies",
-    "requires": "|@Trophies:236|",
-    "category": []
-  },
-  {
-    "name": "Gather 237 Trophies",
-    "requires": "|@Trophies:237|",
-    "category": []
-  },
-  {
-    "name": "Gather 238 Trophies",
-    "requires": "|@Trophies:238|",
-    "category": []
-  },
-  {
-    "name": "Gather 239 Trophies",
-    "requires": "|@Trophies:239|",
-    "category": []
-  },
-  {
-    "name": "Gather 240 Trophies",
-    "requires": "|@Trophies:240|",
-    "category": []
-  },
-  {
-    "name": "Gather 241 Trophies",
-    "requires": "|@Trophies:241|",
-    "category": []
-  },
-  {
-    "name": "Gather 242 Trophies",
-    "requires": "|@Trophies:242|",
-    "category": []
-  },
-  {
-    "name": "Gather 243 Trophies",
-    "requires": "|@Trophies:243|",
-    "category": []
-  },
-  {
-    "name": "Gather 244 Trophies",
-    "requires": "|@Trophies:244|",
-    "category": []
-  },
-  {
-    "name": "Gather 245 Trophies",
-    "requires": "|@Trophies:245|",
-    "category": []
-  },
-  {
-    "name": "Gather 246 Trophies",
-    "requires": "|@Trophies:246|",
-    "category": []
-  },
-  {
-    "name": "Gather 247 Trophies",
-    "requires": "|@Trophies:247|",
-    "category": []
-  },
-  {
-    "name": "Gather 248 Trophies",
-    "requires": "|@Trophies:248|",
-    "category": []
-  },
-  {
-    "name": "Gather 249 Trophies",
-    "requires": "|@Trophies:249|",
-    "category": []
-  },
-  {
-    "name": "Gather 250 Trophies",
-    "requires": "|@Trophies:250|",
-    "category": []
-  },
-  {
-    "name": "Gather 251 Trophies",
-    "requires": "|@Trophies:251|",
-    "category": []
-  },
-  {
-    "name": "Gather 252 Trophies",
-    "requires": "|@Trophies:252|",
-    "category": []
-  },
-  {
-    "name": "Gather 253 Trophies",
-    "requires": "|@Trophies:253|",
-    "category": []
-  },
-  {
-    "name": "Gather 254 Trophies",
-    "requires": "|@Trophies:254|",
-    "category": []
-  },
-  {
-    "name": "Gather 255 Trophies",
-    "requires": "|@Trophies:255|",
-    "category": []
-  },
-  {
-    "name": "Gather 256 Trophies",
-    "requires": "|@Trophies:256|",
-    "category": []
-  },
-  {
-    "name": "Gather 257 Trophies",
-    "requires": "|@Trophies:257|",
-    "category": []
-  },
-  {
-    "name": "Gather 258 Trophies",
-    "requires": "|@Trophies:258|",
-    "category": []
-  },
-  {
-    "name": "Gather 259 Trophies",
-    "requires": "|@Trophies:259|",
-    "category": []
-  },
-  {
-    "name": "Gather 260 Trophies",
-    "requires": "|@Trophies:260|",
-    "category": []
-  },
-  {
-    "name": "Gather 261 Trophies",
-    "requires": "|@Trophies:261|",
-    "category": []
-  },
-  {
-    "name": "Gather 262 Trophies",
-    "requires": "|@Trophies:262|",
-    "category": []
-  },
-  {
-    "name": "Gather 263 Trophies",
-    "requires": "|@Trophies:263|",
-    "category": []
-  },
-  {
-    "name": "Gather 264 Trophies",
-    "requires": "|@Trophies:264|",
-    "category": []
-  },
-  {
-    "name": "Gather 265 Trophies",
-    "requires": "|@Trophies:265|",
-    "category": []
-  },
-  {
-    "name": "Gather 266 Trophies",
-    "requires": "|@Trophies:266|",
-    "category": []
-  },
-  {
-    "name": "Gather 267 Trophies",
-    "requires": "|@Trophies:267|",
-    "category": []
-  },
-  {
-    "name": "Gather 268 Trophies",
-    "requires": "|@Trophies:268|",
-    "category": []
-  },
-  {
-    "name": "Gather 269 Trophies",
-    "requires": "|@Trophies:269|",
-    "category": []
-  },
-  {
-    "name": "Gather 270 Trophies",
-    "requires": "|@Trophies:270|",
-    "category": []
-  },
-  {
-    "name": "Gather 271 Trophies",
-    "requires": "|@Trophies:271|",
-    "category": []
-  },
-  {
-    "name": "Gather 272 Trophies",
-    "requires": "|@Trophies:272|",
-    "category": []
-  },
-  {
-    "name": "Gather 273 Trophies",
-    "requires": "|@Trophies:273|",
-    "category": []
-  },
-  {
-    "name": "Gather 274 Trophies",
-    "requires": "|@Trophies:274|",
-    "category": []
-  },
-  {
-    "name": "Gather 275 Trophies",
-    "requires": "|@Trophies:275|",
-    "category": []
-  },
-  {
-    "name": "Gather 276 Trophies",
-    "requires": "|@Trophies:276|",
-    "category": []
-  },
-  {
-    "name": "Gather 277 Trophies",
-    "requires": "|@Trophies:277|",
-    "category": []
-  },
-  {
-    "name": "Gather 278 Trophies",
-    "requires": "|@Trophies:278|",
-    "category": []
-  },
-  {
-    "name": "Gather 279 Trophies",
-    "requires": "|@Trophies:279|",
-    "category": []
-  },
-  {
-    "name": "Gather 280 Trophies",
-    "requires": "|@Trophies:280|",
-    "category": []
-  },
-  {
-    "name": "Gather 281 Trophies",
-    "requires": "|@Trophies:281|",
-    "category": []
-  },
-  {
-    "name": "Gather 282 Trophies",
-    "requires": "|@Trophies:282|",
-    "category": []
-  },
-  {
-    "name": "Gather 283 Trophies",
-    "requires": "|@Trophies:283|",
-    "category": []
-  },
-  {
-    "name": "Gather 284 Trophies",
-    "requires": "|@Trophies:284|",
-    "category": []
-  },
-  {
-    "name": "Gather 285 Trophies",
-    "requires": "|@Trophies:285|",
-    "category": []
-  },
-  {
-    "name": "Gather 286 Trophies",
-    "requires": "|@Trophies:286|",
-    "category": []
-  },
-  {
-    "name": "Gather 287 Trophies",
-    "requires": "|@Trophies:287|",
-    "category": []
-  },
-  {
-    "name": "Gather 288 Trophies",
-    "requires": "|@Trophies:288|",
-    "category": []
-  },
-  {
-    "name": "Gather 289 Trophies",
-    "requires": "|@Trophies:289|",
-    "category": []
-  },
-  {
-    "name": "Gather 290 Trophies",
-    "requires": "|@Trophies:290|",
-    "category": []
-  },
-  {
-    "name": "Gather 291 Trophies",
-    "requires": "|@Trophies:291|",
-    "category": []
-  },
-  {
-    "name": "Gather 292 Trophies",
-    "requires": "|@Trophies:292|",
-    "category": []
-  },
-  {
-    "name": "Gather 293 Trophies",
-    "requires": "|@Trophies:293|",
-    "category": []
-  },
-  {
-    "name": "Gather 294 Trophies",
-    "requires": "|@Trophies:294|",
-    "category": []
-  },
-  {
-    "name": "Gather 295 Trophies",
-    "requires": "|@Trophies:295|",
-    "category": []
-  },
-  {
-    "name": "Gather 296 Trophies",
-    "requires": "|@Trophies:296|",
-    "category": []
-  },
-  {
-    "name": "Gather 297 Trophies",
-    "requires": "|@Trophies:297|",
-    "category": []
-  },
-  {
-    "name": "Gather 298 Trophies",
-    "requires": "|@Trophies:298|",
-    "category": []
-  },
-  {
-    "name": "Gather 299 Trophies",
-    "requires": "|@Trophies:299|",
     "category": []
   },
 	{

--- a/hooks/Options.py
+++ b/hooks/Options.py
@@ -139,4 +139,5 @@ def before_options_defined(options: dict) -> dict:
 
 # This is called after any manual options are defined, in case you want to see what options are defined or want to modify the defined options
 def after_options_defined(options: dict) -> dict:
+    options["goal"].visibility = 8 #hidden
     return options

--- a/hooks/World.py
+++ b/hooks/World.py
@@ -65,8 +65,8 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
     # to the list multiple times if you want to remove multiple copies of it.
     
     # Get the victory item out of the pool:
-    victory_item = next(i for i in item_pool if i.name == "Ultimate Trophy (Victory)")
-    item_pool.remove(victory_item)
+    # victory_item = next(i for i in item_pool if i.name == "Ultimate Trophy (Victory)")
+    # item_pool.remove(victory_item)
     
     # Get Trophy Information
     tracks = 17
@@ -92,13 +92,13 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
     percent = get_option_value(multiworld, player, "percentage_trophies") / 100
     trophies = round(max_trophies * percent)
 
-    bad_trophies = 300-max_trophies
+    bad_trophies = 172-max_trophies
     for i in range(bad_trophies):
         itemNamesToRemove.append("Trophy")
 
     # Get the victory location and place the victory item there
     victory_loc_list = ["Gather 1 Trophy"]  # A list of all the victory location names in order
-    for i in range(2,300):
+    for i in range(2,172):
         victory_loc_list.append(f"Gather {i} Trophies")
     
     for i in range(len(victory_loc_list)-1):
@@ -109,7 +109,7 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
     #victory_id = get_option_value(multiworld, player, "victory_condition") # This needs to be added in the hooks/Options.py file
     victory_location_name = victory_loc_list[victory_id]
     victory_location = next(l for l in multiworld.get_unfilled_locations(player=player) if l.name == victory_location_name)
-    victory_location.place_locked_item(victory_item)
+    # victory_location.place_locked_item(victory_item)
     
     # Remove the extra victory locations
     for region in multiworld.regions:

--- a/hooks/World.py
+++ b/hooks/World.py
@@ -107,7 +107,7 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
             break
 
     #victory_id = get_option_value(multiworld, player, "victory_condition") # This needs to be added in the hooks/Options.py file
-    #victory_location_name = victory_loc_list[victory_id]
+    victory_location_name = victory_loc_list[victory_id]
     #victory_location = next(l for l in multiworld.get_unfilled_locations(player=player) if l.name == victory_location_name)
     # victory_location.place_locked_item(victory_item)
     

--- a/hooks/World.py
+++ b/hooks/World.py
@@ -107,8 +107,8 @@ def before_create_items_filler(item_pool: list, world: World, multiworld: MultiW
             break
 
     #victory_id = get_option_value(multiworld, player, "victory_condition") # This needs to be added in the hooks/Options.py file
-    victory_location_name = victory_loc_list[victory_id]
-    victory_location = next(l for l in multiworld.get_unfilled_locations(player=player) if l.name == victory_location_name)
+    #victory_location_name = victory_loc_list[victory_id]
+    #victory_location = next(l for l in multiworld.get_unfilled_locations(player=player) if l.name == victory_location_name)
     # victory_location.place_locked_item(victory_item)
     
     # Remove the extra victory locations


### PR DESCRIPTION
Due to recent versions allowing multiple victory locations, having a separate check will be obsolete.

Also, removed locations starting from "Gather 173 Trophies" to max since doing a gen with everything enabled comes up with 172 trophies.

Expected for the hook to be rewritten by Hallstead before pushing the update with this PR.